### PR TITLE
Add findOneAndUpdate and without $set support

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -127,11 +127,12 @@ const fieldEncryption = function(schema, options) {
   function updateHook(_next) {
     const next = getCompatitibleNextFunc(_next);
     for (let field of fieldsToEncrypt) {
-      let encryptedFieldName = encryptedFieldNamePrefix + field;
+      const encryptedFieldName = encryptedFieldNamePrefix + field;
       this._update.$set = this._update.$set || {};
-      let plainTextValue = this._update.$set[field] || this._update[field];
+      const plainTextValue = this._update.$set[field] || this._update[field];
+      const encryptedFieldValue = this._update.$set[encryptedFieldName] || this._update[encryptedFieldName];
 
-      if (plainTextValue) {
+      if (!encryptedFieldValue && plainTextValue) {
         let updateObj = {};
         if (typeof plainTextValue === "string" || plainTextValue instanceof String) {
           const encryptedData = encrypt(plainTextValue, secret);
@@ -139,10 +140,10 @@ const fieldEncryption = function(schema, options) {
           updateObj[field] = encryptedData;
           updateObj[encryptedFieldName] = true;
         } else {
-          const encryptedFileData = encryptedFieldName + encryptedFieldDataSuffix;
+          const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
 
           updateObj[field] = undefined;
-          updateObj[encryptedFileData] = encrypt(JSON.stringify(plainTextValue), secret);
+          updateObj[encryptedFieldData] = encrypt(JSON.stringify(plainTextValue), secret);
           updateObj[encryptedFieldName] = true;
         }
         this.update({}, Object.keys(this._update.$set) > 0 ? { $set: updateObj } : updateObj);

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -124,29 +124,37 @@ const fieldEncryption = function(schema, options) {
     }
   });
 
-  schema.pre("update", function(_next) {
+  function updateHook(_next) {
     const next = getCompatitibleNextFunc(_next);
     for (let field of fieldsToEncrypt) {
       let encryptedFieldName = encryptedFieldNamePrefix + field;
-      let encryptedFieldValue = this._update.$set[encryptedFieldName];
-      let plainTextValue = this._update.$set[field];
+      this._update.$set = this._update.$set || {};
+      let plainTextValue = this._update.$set[field] || this._update[field];
 
-      if (encryptedFieldValue === false && plainTextValue) {
+      if (plainTextValue) {
+        let updateObj = {};
         if (typeof plainTextValue === "string" || plainTextValue instanceof String) {
-          let updateObj = { $set: {} };
-          updateObj.$set[field] = encrypt(plainTextValue, secret);
-          updateObj.$set[encryptedFieldName] = true;
-          this.update({}, updateObj);
+          const encryptedData = encrypt(plainTextValue, secret);
+
+          updateObj[field] = encryptedData;
+          updateObj[encryptedFieldName] = true;
         } else {
-          return next(
-            new Error("Cannot apply mongoose-field-encryption plugin on update to encrypt non string fields")
-          );
+          const encryptedFileData = encryptedFieldName + encryptedFieldDataSuffix;
+
+          updateObj[field] = undefined;
+          updateObj[encryptedFileData] = encrypt(JSON.stringify(plainTextValue), secret);
+          updateObj[encryptedFieldName] = true;
         }
+        this.update({}, Object.keys(this._update.$set) > 0 ? { $set: updateObj } : updateObj);
       }
     }
 
     next();
-  });
+  }
+
+  schema.pre("findOneAndUpdate", updateHook);
+
+  schema.pre("update", updateHook);
 
   schema.methods.stripEncryptionFieldMarkers = function() {
     for (let field of fieldsToEncrypt) {

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -253,4 +253,61 @@ describe("mongoose-field-encryption plugin db", function() {
         expect(found.toEncryptObject.nested).to.eql("snoop");
       });
   });
+
+  it("should encrypt non string fields on fineOneAndUpdate without $set", () => {
+    // given
+    let sut = getSut();
+
+    // when
+    return sut
+      .save()
+      .then(() => {
+        expectEncryptionValues(sut);
+
+        return NestedFieldEncryption.findOneAndUpdate(
+          {
+            _id: sut._id
+          },
+          {
+            toEncryptObject: { nested: "snoop" }
+          }
+        );
+      })
+      .then(() => {
+        return NestedFieldEncryption.findById(sut._id);
+      })
+      .then(found => {
+        expect(found.toEncryptObject.nested).to.eql("snoop");
+      });
+  });
+
+  it ("should not encrypt already encrypted fields", () => {
+    // given
+    let sut = getSut();
+
+    // when
+    return sut
+      .save()
+      .then(() => {
+        expectEncryptionValues(sut);
+
+        return NestedFieldEncryption.update(
+          {
+            _id: sut._id
+          },
+          {
+            $set: {
+              toEncryptString: "already encrypted string",
+              __enc_toEncryptObject: true
+            }
+          }
+        );
+      })
+      .then(() => {
+        return NestedFieldEncryption.findById(sut._id);
+      })
+      .then(found => {
+        expect(found.toEncryptString).to.eql("already encrypted string");
+      });
+  })
 });

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -174,6 +174,31 @@ describe("mongoose-field-encryption plugin db", function() {
       });
   });
 
+  it("should encrypt string fields on update without $set", () => {
+    // given
+    let sut = getSut();
+
+    // when
+    return sut
+      .save()
+      .then(() => {
+        expectEncryptionValues(sut);
+
+        return NestedFieldEncryption.update(
+          { _id: sut._id },
+          { toEncryptString: "snoop" }
+        );
+      })
+      .then(() => {
+        return NestedFieldEncryption.findById(sut._id);
+      })
+      .then(found => {
+        // then
+        expect(found.__enc_toEncryptString).to.be.false;
+        expect(found.toEncryptString).to.equal("snoop");
+      });
+  });
+
   it("should encrypt string fields on fineOneAndUpdate", () => {
     // given
     let sut = getSut();

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -174,7 +174,32 @@ describe("mongoose-field-encryption plugin db", function() {
       });
   });
 
-  it("should not encrypt non string fields on update", () => {
+  it("should encrypt string fields on fineOneAndUpdate", () => {
+    // given
+    let sut = getSut();
+
+    // when
+    return sut
+      .save()
+      .then(() => {
+        expectEncryptionValues(sut);
+
+        return NestedFieldEncryption.findOneAndUpdate(
+          { _id: sut._id },
+          { $set: { toEncryptString: "snoop", __enc_toEncryptString: false } }
+        );
+      })
+      .then(() => {
+        return NestedFieldEncryption.findById(sut._id);
+      })
+      .then(found => {
+        // then
+        expect(found.__enc_toEncryptString).to.be.false;
+        expect(found.toEncryptString).to.equal("snoop");
+      });
+  })
+
+  it("should encrypt non string fields on update", () => {
     // given
     let sut = getSut();
 

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -247,12 +247,10 @@ describe("mongoose-field-encryption plugin db", function() {
         );
       })
       .then(() => {
-        expect.fail("should not have updated");
+        return NestedFieldEncryption.findById(sut._id);
       })
-      .catch(err => {
-        // then
-        // TODO: this is a mongoose cast error
-        expect(err).to.not.be.null;
+      .then(found => {
+        expect(found.toEncryptObject.nested).to.eql("snoop");
       });
   });
 });


### PR DESCRIPTION
This pr should add the missing hook for findOneAndUpdate since it is a native mongodb call, mongoose has different calls for that and update.
It should also add a feature to work with $set and without $set.
Closes #14 