### PR TITLE
Check if the field exists before decryption

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -138,11 +138,13 @@ const fieldEncryption = function(schema, options) {
           obj[encryptedFieldName] = false;
           obj[encryptedFieldData] = "";
         } else {
+          // If the field has been marked to not be retrieved, it'll be undefined
+          if (obj[field]) {
           // handle strings separately to maintain searchability
-          const encryptedValue = obj[field];
-
-          obj[field] = decrypt(encryptedValue, secret);
-          obj[encryptedFieldName] = false;
+            const encryptedValue = obj[field];
+            obj[field] = decrypt(encryptedValue, secret);
+            obj[encryptedFieldName] = false;
+          }
         }
       }
     }


### PR DESCRIPTION
Sometimes the field could be marked to not be retrieved, in that case, the decrypt function will fail because because the field is undefined.