### PR TITLE
Add secret factory for defering salt generation/loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const results = await Message.find({ name: messageToSearchWith.name });
 ### Options
 
 - `fields` (required): an array list of the required fields
-- `secret` (required): a string cipher which is used to encrypt the data (don't lose this!)
+- `secret` (required): a string cipher (or a synchronous factory function which returns a string cipher) which is used to encrypt the data (don't lose this!)
 - `useAes256Ctr` (optional, default `false`): a boolean indicating whether the older `aes-256-ctr` algorithm should be used. Note that this is strictly a backwards compatibility feature and for new installations it is recommended to leave this at default.
 - `saltGenerator` (optional, default `const defaultSaltGenerator = secret => crypto.randomBytes(16);`): a function that should return either a `utf-8` encoded string that is 16 characters in length or a `Buffer` of length 16. This function is also passed the secret as shown in the default function example.
 

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -80,10 +80,17 @@ const fieldEncryption = function(schema, options) {
   const useAes256Ctr = options.useAes256Ctr || false;
   const fieldsToEncrypt = options.fields || [];
 
-  const hash = crypto.createHash("sha256");
-  hash.update(options.secret);
+  const _secret = typeof options.secret === 'function'
+                    ? options.secret
+                    : () => options.secret;
 
-  const secret = useAes256Ctr ? options.secret : hash.digest("hex").substring(0, 32);
+  console.log(_secret, typeof _secret);
+  
+  const _hash = secret => crypto.createHash("sha256").update(secret).digest("hex").substring(0, 32);
+
+  const secret = useAes256Ctr
+					? _secret
+					: () => _hash(_secret());
   const encryptionStrategy = useAes256Ctr ? encryptAes256Ctr : encrypt;
   const saltGenerator = options.saltGenerator ? options.saltGenerator : defaultSaltGenerator;
 
@@ -182,7 +189,7 @@ const fieldEncryption = function(schema, options) {
       if (!encryptedFieldValue && plainTextValue) {
         const updateObj = {};
         if (typeof plainTextValue === "string" || plainTextValue instanceof String) {
-          const encryptedData = encryptionStrategy(plainTextValue, secret, saltGenerator);
+          const encryptedData = encryptionStrategy(plainTextValue, secret(), saltGenerator);
 
           updateObj[field] = encryptedData;
           updateObj[encryptedFieldName] = true;
@@ -190,7 +197,7 @@ const fieldEncryption = function(schema, options) {
           const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
 
           updateObj[field] = undefined;
-          updateObj[encryptedFieldData] = encryptionStrategy(JSON.stringify(plainTextValue), secret, saltGenerator);
+          updateObj[encryptedFieldData] = encryptionStrategy(JSON.stringify(plainTextValue), secret(), saltGenerator);
           updateObj[encryptedFieldName] = true;
         }
         this.update({}, Object.keys(this._update.$set).length > 0 ? { $set: updateObj } : updateObj);
@@ -215,11 +222,11 @@ const fieldEncryption = function(schema, options) {
   };
 
   schema.methods.decryptFieldsSync = function() {
-    decryptFields(this, fieldsToEncrypt, secret);
+    decryptFields(this, fieldsToEncrypt, secret());
   };
 
   schema.methods.encryptFieldsSync = function() {
-    encryptFields(this, fieldsToEncrypt, secret);
+    encryptFields(this, fieldsToEncrypt, secret());
   };
 
   //
@@ -230,7 +237,7 @@ const fieldEncryption = function(schema, options) {
     const next = getCompatitibleNextFunc(_next);
     const data = getCompatibleData(_next, _data);
     try {
-      decryptFields(data, fieldsToEncrypt, secret);
+      decryptFields(data, fieldsToEncrypt, secret());
       next();
     } catch (err) {
       next(err);
@@ -241,7 +248,7 @@ const fieldEncryption = function(schema, options) {
     const next = getCompatitibleNextFunc(_next);
 
     try {
-      encryptFields(this, fieldsToEncrypt, secret);
+      encryptFields(this, fieldsToEncrypt, secret());
       next();
     } catch (err) {
       next(err);

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -96,6 +96,52 @@ describe("mongoose-field-encryption plugin db", function() {
     runTests(NestedFieldEncryption, getSut, expectEncryptionValues, expectDecryptionValues);
   });
 
+  describe("simple setup with salt factory", function() {
+    const NestedFieldEncryptionSaltFactorySchema = new mongoose.Schema(MongooseSchema);
+
+    NestedFieldEncryptionSaltFactorySchema.plugin(
+      fieldEncryptionPlugin,
+      {
+          ...fieldEncryptionPluginOptions,
+          secret: () => fieldEncryptionPluginOptions.secret
+      }
+    );
+
+    const NestedFieldEncryptionSaltFactory = mongoose.model("NestedFieldEncryptionSaltFactory", NestedFieldEncryptionSaltFactorySchema);
+
+    function expectEncryptionValues(sut) {
+      expect(sut.__enc_toEncryptString).to.be.true;
+
+      expect(sut.toObject().toEncryptObject).to.be.undefined;
+      expect(sut.__enc_toEncryptObject).to.be.true;
+
+      expect(sut.toObject().toEncryptArray).to.be.undefined;
+      expect(sut.__enc_toEncryptArray).to.be.true;
+
+      expect(sut.toObject().toEncryptDate).to.be.undefined;
+      expect(sut.__enc_toEncryptDate).to.be.true;
+    }
+
+    function expectDecryptionValues(found) {
+      expect(found.toEncryptString).to.equal("hide me!");
+      expect(found.__enc_toEncryptString).to.be.false;
+
+      expect(JSON.stringify(found.toEncryptObject)).to.equal('{"nested":"some stuff to encrypt"}');
+      expect(found.__enc_toEncryptObject).to.be.false;
+      expect(found.__enc_toEncryptObject_d).to.equal("");
+
+      expect(JSON.stringify(found.toEncryptArray)).to.equal("[1,2,3]");
+      expect(found.__enc_toEncryptArray).to.be.false;
+      expect(found.__enc_toEncryptArray_d).to.equal("");
+
+      expect(JSON.stringify(found.toEncryptDate)).to.equal('"2017-01-28T22:04:08.338Z"');
+      expect(found.__enc_toEncryptDate).to.be.false;
+      expect(found.__enc_toEncryptDate_d).to.equal("");
+    }
+
+    runTests(NestedFieldEncryptionSaltFactory, getSut, expectEncryptionValues, expectDecryptionValues);
+  });
+
   describe("custom salt", function() {
     const NestedFieldEncryptionCustomSaltSchema = new mongoose.Schema(MongooseSchema);
 

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -36,4 +36,14 @@ describe("mongoose-field-encryption plugin setup", function() {
     // then
     done();
   });
+
+  it("should initialize plugin with secret factory function", function(done) {
+    // when
+    FieldEncryptionSchema.plugin(fieldEncryptionPlugin, {
+      secret: () => "icanhazcheezburger"
+    });
+
+    // then
+    done();
+  });
 });


### PR DESCRIPTION
Adds the option to pass a factory function as the secret. E.g.:
```
MongooseSchema.plugin(mongooseFieldEncryption, {
  secret: () => "my-super-secret-code123"
});
```