### PR TITLE
Failing test for encrypted fields inside array of subschemas

### DIFF
--- a/test/test-nested-fields.js
+++ b/test/test-nested-fields.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const crypto = require("crypto");
+const expect = require("chai").expect;
+const mongoose = require("mongoose");
+const Promise = require("bluebird");
+const Schema = mongoose.Schema;
+
+mongoose.Promise = Promise;
+mongoose.set("bufferCommands", false);
+
+const mongooseFieldEncryption = require("../lib/mongoose-field-encryption").fieldEncryption;
+
+const uri = process.env.URI || "mongodb://127.0.0.1:27017/mongoose-field-encryption-test";
+
+describe("nested fields", function () {
+  this.timeout(5000);
+
+  before(function (done) {
+    mongoose
+      .connect(uri, { useNewUrlParser: true, promiseLibrary: Promise, autoIndex: false, useUnifiedTopology: true })
+      .then(function () {
+        done();
+      });
+
+    mongoose.set("useFindAndModify", false);
+  });
+
+  after(function (done) {
+    mongoose.disconnect().then(function () {
+      done();
+    });
+  });
+
+  it("should save a document with a nested schema", function (done) {
+    // given
+    const nestedAuthorSchema = new Schema({
+      name: String,
+      password: String,
+    });
+    nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
+    const postSchema = new Schema({
+      title: String,
+      message: String,
+      author: nestedAuthorSchema,
+    });
+
+    const Post = mongoose.model("Post1", postSchema);
+    const post = new Post({
+      title: "some text",
+      message: "hello all",
+      author: { name: "some name", password: "some password" },
+    });
+
+    // when
+    post.save(function (err) {
+      // then
+      if (err) {
+        return done(err);
+      }
+
+      expect(post.author.name).to.equal("some name");
+      expect(post.author.password).to.not.be.undefined;
+      const split = post.author.password.split(":");
+      expect(split.length).to.equal(2);
+      expect(post.author.__enc_password).to.be.true;
+
+      console.dir(post.toObject());
+
+      done();
+    });
+  });
+
+  it("should update a document with a nested schema", function (done) {
+    // given
+    const nestedAuthorSchema = new Schema({
+      name: String,
+      password: String,
+    });
+    nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
+    const postSchema = new Schema({
+      title: String,
+      message: String,
+      author: nestedAuthorSchema,
+    });
+
+    const Post = mongoose.model("Post2", postSchema);
+    const post = new Post({
+      title: "some text",
+      message: "hello all",
+      author: { name: "some name", password: "some password" },
+    });
+
+    post.save(function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      Post.findOne({ _id: post._id }, function (err, post) {
+        if (err) {
+          return done(err);
+        }
+
+        post.author.name = "something else";
+
+        // when
+        post.save(function (err) {
+          // then
+          if (err) {
+            return done(err);
+          }
+
+          expect(post.author.name).to.equal("something else");
+          console.dir(post.toObject());
+          done();
+        });
+      });
+    });
+  });
+
+  it("should update a document with a nested schema-array", function (done) {
+    // given
+    const nestedAuthorSchema = new Schema({
+      name: String,
+      password: String,
+    });
+    nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
+    const postSchema = new Schema({
+      title: String,
+      message: String,
+      authors: [nestedAuthorSchema],
+    });
+
+    const Post = mongoose.model("Post3", postSchema);
+    const post = new Post({
+      title: "some text",
+      message: "hello all",
+      authors: [{ name: "some name", password: "some password" }],
+    });
+
+    post.save(function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      Post.findOne({ _id: post._id }, function (err, post) {
+        if (err) {
+          return done(err);
+        }
+
+        post.authors[0].name = "something else";
+
+        // when
+        post.save(function (err) {
+          // then
+          if (err) {
+            return done(err);
+          }
+
+          expect(post.authors[0].name).to.equal("something else");
+          console.dir(post.toObject());
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
I've come across an issue where updating a field on a document whose schema contains an array of subschemas with encrypted fields fails with an error:

```
MongoError: Cannot create field '-1' in element {authors: [ { _id: ObjectId('5fb15d804f08f82bb8decc0f'), name: "some name", password: "7d1a3a58ff4820c49c21a02a772e09af:455079abc165c43f53f0c0b6df455b37", __enc_password: true } ]}
```

In this PR, I'm adding a test in `test/test-nested-fields.js`: `it should update a document with a nested schema-array` which should pass, but fails with the error above.

Setting mongoose's `debug` to `true`, reveals that the following update is being attempted:

```js
post3.updateOne(
	{ _id: ObjectId('5fb15fb19823c12e6954e466'), __v: 0 },
	{
		$set: {
                         // 👇 This looks problematic
			'authors.-1.__enc_password': [undefined],
			'authors.-1.password': [undefined],
                         // 👆 This looks problematic
			'authors.0.__enc_password': true,
			'authors.0.name': 'something else',
			'authors.0.password': '7a48362158513b122aa464e79dd66a7f:e6ace493268413f0c7fffd8270390583',
		},
		$inc: { __v: 1 },
	},
	{ session: undefined }
)
```