### PR TITLE
Failing test: updating document with array of subdocuments that have encrypted fields

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -243,6 +243,42 @@ const fieldEncryption = function (schema, options) {
 
     try {
       encryptFields(this, fieldsToEncrypt, secret());
+
+      function markPathsAsModified(doc) {
+        let modifiedPath = "";
+        let parent = doc.parent();
+        if (!parent) {
+          return;
+        }
+
+        for (const [key, value] of Object.entries(parent._doc)) {
+          if (Array.isArray(value)) {
+            const index = value.findIndex((v) => v === doc);
+            if (index !== -1) {
+              modifiedPath = `${key}.${index}`;
+              break;
+            }
+          } else if (value === doc) {
+            modifiedPath = key;
+            break;
+          }
+        }
+
+        if (modifiedPath) {
+          parent.set(modifiedPath, doc.toObject());
+
+          const grandParent = parent.parent();
+          if (grandParent) {
+            markPathsAsModified(parent);
+          }
+        }
+      }
+
+      const hasParent = !!this.parent();
+      if (hasParent) {
+        markPathsAsModified(this);
+      }
+
       next();
     } catch (err) {
       next(err);

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -251,7 +251,9 @@ const fieldEncryption = function (schema, options) {
           return;
         }
 
-        for (const [key, value] of Object.entries(parent._doc)) {
+        const entries = Object.keys(parent._doc).map((key) => [key, parent._doc[key]]);
+
+        for (const [key, value] of entries) {
           if (Array.isArray(value)) {
             const index = value.findIndex((v) => v === doc);
             if (index !== -1) {

--- a/test/test-nested-fields.js
+++ b/test/test-nested-fields.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const crypto = require("crypto");
+const expect = require("chai").expect;
+const mongoose = require("mongoose");
+const Promise = require("bluebird");
+const Schema = mongoose.Schema;
+
+mongoose.Promise = Promise;
+mongoose.set("bufferCommands", false);
+
+const mongooseFieldEncryption = require("../lib/mongoose-field-encryption").fieldEncryption;
+
+const uri = process.env.URI || "mongodb://127.0.0.1:27017/mongoose-field-encryption-test";
+
+describe("nested fields", function () {
+  this.timeout(5000);
+
+  before(function (done) {
+    mongoose
+      .connect(uri, { useNewUrlParser: true, promiseLibrary: Promise, autoIndex: false, useUnifiedTopology: true })
+      .then(function () {
+        done();
+      });
+
+    mongoose.set("useFindAndModify", false);
+  });
+
+  after(function (done) {
+    mongoose.disconnect().then(function () {
+      done();
+    });
+  });
+
+  it("should save a document with a nested schema", function (done) {
+    // given
+    const nestedAuthorSchema = new Schema({
+      name: String,
+      password: String,
+    });
+    nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
+    const postSchema = new Schema({
+      title: String,
+      message: String,
+      author: nestedAuthorSchema,
+    });
+
+    const Post = mongoose.model("Post1", postSchema);
+    const post = new Post({
+      title: "some text",
+      message: "hello all",
+      author: { name: "some name", password: "some password" },
+    });
+
+    // when
+    post.save(function (err) {
+      // then
+      if (err) {
+        return done(err);
+      }
+
+      expect(post.author.name).to.equal("some name");
+      expect(post.author.password).to.not.be.undefined;
+      const split = post.author.password.split(":");
+      expect(split.length).to.equal(2);
+      expect(post.author.__enc_password).to.be.true;
+
+      console.dir(post.toObject());
+
+      done();
+    });
+  });
+
+  it("should update a document with a nested schema", function (done) {
+    // given
+    const nestedAuthorSchema = new Schema({
+      name: String,
+      password: String,
+    });
+    nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
+    const postSchema = new Schema({
+      title: String,
+      message: String,
+      author: nestedAuthorSchema,
+    });
+
+    const Post = mongoose.model("Post2", postSchema);
+    const post = new Post({
+      title: "some text",
+      message: "hello all",
+      author: { name: "some name", password: "some password" },
+    });
+
+    post.save(function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      Post.findOne({ _id: post._id }, function (err, post) {
+        if (err) {
+          return done(err);
+        }
+
+        post.author.name = "something else";
+
+        // when
+        post.save(function (err) {
+          // then
+          if (err) {
+            return done(err);
+          }
+
+          expect(post.author.name).to.equal("something else");
+          console.dir(post.toObject());
+          done();
+        });
+      });
+    });
+  });
+
+  // Failing test:
+  it("should update a document with a nested schema-array", function (done) {
+    // given
+    const nestedAuthorSchema = new Schema({
+      name: String,
+      password: String,
+    });
+    nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
+    const postSchema = new Schema({
+      title: String,
+      message: String,
+      authors: [nestedAuthorSchema],
+    });
+
+    const Post = mongoose.model("Post3", postSchema);
+    const post = new Post({
+      title: "some text",
+      message: "hello all",
+      authors: [{ name: "some name", password: "some password" }],
+    });
+
+    post.save(function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      Post.findOne({ _id: post._id }, function (err, post) {
+        if (err) {
+          return done(err);
+        }
+
+        post.title = "something else";
+
+        // when
+        post.save(function (err) {
+          // then
+          if (err) {
+            return done(err);
+          }
+
+          expect(post.authors[0].name).to.equal("something else");
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/test-nested-fields.js
+++ b/test/test-nested-fields.js
@@ -158,7 +158,7 @@ describe("nested fields", function () {
             return done(err);
           }
 
-          expect(post.authors[0].name).to.equal("something else");
+          expect(post.title).to.equal("something else");
           done();
         });
       });


### PR DESCRIPTION
Hi!

I've noticed an issue when mongoose-field-encryption is used in a subdocument that is inside an array of its parent.

Something like this:

```js
const nestedAuthorSchema = new Schema({
    name: String,
    password: String,
});
nestedAuthorSchema.plugin(mongooseFieldEncryption, { fields: ["password"], secret: "some secret key" });
const postSchema = new Schema({
    title: String,
    message: String,
    authors: [nestedAuthorSchema],
});
const Post = mongoose.model("Post3", postSchema);
```

If you attempt to update the parent and save it using `Document.prototype.save()`, you get an error similar to the following:

```
const post = await Post.findOne({})
post.title = "Something"
await post.save()

// 💥
// MongoError: Cannot create field '-1' in element {authors: [ { _id: ObjectId('5fbac6eb2ae2b1cd93ef2ac4'), name: "some name", password: "26518a99edf664ea97c38108214f4d14:b86ecce381e3c8dc7930f6ae7f139437", __enc_password: true } ]}
```

I've included a failing test in the PR: https://github.com/wheresvic/mongoose-field-encryption/pull/49/files#diff-755667fe9b6408db7a3d8206cd5830c4c912027bbf2290f90adea9713bc5324cR121-R167

This problem occurs because `post-init`, fields are first encrypted and then `pre-save` they are encrypted again. Because mongoose has issues tracking changes that occur in arrays without explicitly setting `document.array.set(index, changedObject)`, the error above occurs:

```js
  // Every subdocument that has mongoose-field-encryption as a plugin,
  // will get decrypted after it's fetched from the db:
  schema.post("init", function (_next, _data) {
    const next = getCompatitibleNextFunc(_next);
    const data = getCompatibleData(_next, _data);
    try {
      decryptFields(data, fieldsToEncrypt, secret());
      next();
    } catch (err) {
      next(err);
    }
  });

  schema.pre("save", function (_next) {
    const next = getCompatitibleNextFunc(_next);

    try {
      // ⚠️ After encrypting here, we need to tell mongoose which indexes were affected
      // in case `this` is a sub-document inside an array.
      // 🚧 Problem: We can get the parent document with `this.parent()` but how do we know
      // which path and index this sub-document belongs to?
      encryptFields(this, fieldsToEncrypt, secret());
      next();
    } catch (err) {
      next(err);
    }
  });
```

So, after encrypting `pre-save`, we need to tell mongoose which sub-documents in the array changed. What I'm not sure about: **How, in a pre-save hook of a subdocument, can we tell which path and index the subdocument belongs to?**

I'm thankful for input and ideas! Thanks!