### PR TITLE
.select workaround based on field names for find and findOne 

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -172,6 +172,19 @@ const fieldEncryption = function (schema, options) {
     }
   }
 
+  function findHook(_next) {
+    const next = getCompatitibleNextFunc(_next);
+    if (this.$useProjection) {
+      Object.keys(this._fields).forEach(key => {
+        if (fieldsToEncrypt.indexOf(key) === -1) return;
+        if (!this._fields[key] || (this._fields[key] !== 1 && this._fields[key] !== true)) return;
+        this._fields[`__enc_${key}`] = 1;
+        this._fields[`__enc_${key}_d`] = 1;
+      })
+    }
+    next()
+  }
+
   function updateHook(_next) {
     const next = getCompatitibleNextFunc(_next);
     for (const field of fieldsToEncrypt) {
@@ -249,6 +262,7 @@ const fieldEncryption = function (schema, options) {
     }
   });
 
+  schema.pre(['find', 'findOne'], findHook);
   schema.pre("findOneAndUpdate", updateHook);
 
   schema.pre("update", updateHook);


### PR DESCRIPTION
Upon our needs for our business, I've made a workaround on .select with a pre-hook.
This hook automatically adds __enc_key and __enc_key_d for relevant fieldsToEncrypt.

Note: only works on top-level fields at the moment.

Doguhan