### PR TITLE
.d.ts generated and added to package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages
 development/docker-compose.yml
 development/init-mongo.js
 
+dist/

--- a/lib/mongoose-field-encryption.d.ts
+++ b/lib/mongoose-field-encryption.d.ts
@@ -1,0 +1,10 @@
+export function fieldEncryption(schema: any, options: any): void;
+export function encrypt(clearText: any, secret: any, saltGenerator: any): string;
+/**
+ * Decryption has a default fallback for the deprecated algorithm
+ *
+ * @param {*} encryptedHex
+ * @param {*} secret
+ */
+export function decrypt(encryptedHex: any, secret: any): string;
+export function encryptAes256Ctr(text: any, secret: any): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4329,6 +4329,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.3.tgz",
+      "integrity": "sha512-rUvLW0WtF7PF2b9yenwWUi9Da9euvDRhmH7BLyBG4DCFfOJ850LGNknmRpp8Z8kXNUPObdZQEfKOiHtXuQHHKA==",
+      "dev": true
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.2",
   "description": "A simple symmetric encryption plugin for individual fields.",
   "main": "lib/mongoose-field-encryption.js",
+  "types": "lib/mongoose-field-encryption.d.ts",
   "files": [
     "lib/"
   ],
@@ -53,7 +54,8 @@
     "mongoose": "5.10.9",
     "nyc": "15.1.0",
     "release-it": "14.1.0",
-    "sinon": "9.2.0"
+    "sinon": "9.2.0",
+    "typescript": "^4.3.3"
   },
   "release-it": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [
+    "lib/*.js"
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
For #60

Running `npx typescript` regenerates .d.ts into `dist/` folder.

I've moved the generated file to `lib/` folder and added reference `"types": "lib/mongoose-field-encryption.d.ts",` to `package.json`

I hope this works fine.

Doguhan