### PR TITLE
.lean() with post-hook of .find and .findOne

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -110,7 +110,13 @@ const fieldEncryption = function (schema, options) {
     }
   };
 
-  function getCompatitibleNextFunc(next) {
+  function getCompatitibleNextFunc(next, data) {
+    // ! For the post-hook for .find and .findOne data is the first argument,
+    // ! therefore checking for an object in the first argument resolves the 
+    // ! second argument to be next().
+    if (typeof next === "object" && typeof data === "function") {
+      return data;
+    }
     if (typeof next !== "function") {
       return defaultNext;
     }
@@ -120,6 +126,12 @@ const fieldEncryption = function (schema, options) {
   function getCompatibleData(next, data) {
     // in mongoose5, 'data' field is undefined
     if (!data) {
+      return next;
+    }
+    // ! For the post-hook for .find and .findOne data is the first argument,
+    // ! therefore checking for an object in the first argument resolves the 
+    // ! data.
+    if (typeof next === "object") {
       return next;
     }
     return data;
@@ -144,6 +156,13 @@ const fieldEncryption = function (schema, options) {
 
         obj[encryptedFieldName] = true;
       }
+    }
+  }
+
+  function decryptArrayFields(data, fields, secret) {
+    // ! looping through the array of data (multiple docs)
+    for (var obj of data) {
+      decryptFields(obj, fields, secret);
     }
   }
 
@@ -248,6 +267,39 @@ const fieldEncryption = function (schema, options) {
       next(err);
     }
   });
+
+  schema.post('find', function (_next, _data) {
+    const next = getCompatitibleNextFunc(_next, _data);
+    const data = getCompatibleData(_next, _data);
+    // ! checking if the request has lean()
+    if (this._mongooseOptions.lean) {
+      try {
+        // ! Data is being returned as an array. We need to loop through them.
+        decryptArrayFields(data, fieldsToEncrypt, secret());
+        next();
+      } catch (err) {
+        next(err);
+      }
+    } else {
+      next();
+    }
+  })
+
+  schema.post('findOne', function (_next, _data) {
+    const next = getCompatitibleNextFunc(_next, _data);
+    const data = getCompatibleData(_next, _data);
+    // ! checking if the request has lean()
+    if (this._mongooseOptions.lean) {
+      try {
+        decryptFields(data, fieldsToEncrypt, secret());
+        next();
+      } catch (err) {
+        next(err);
+      }
+    } else {
+      next();
+    }
+  })
 
   schema.pre("findOneAndUpdate", updateHook);
 


### PR DESCRIPTION
Hi again 😊

I also had to use .lean functionality in our business as we have over 250 queries running throughout our projects and it would take much more time to replace them all.

So I've added the workaround I came up with, mapping after the document(s) are returned with the post hook for find and findOne.

This seems to be working fine with our tests, I hope you can have time to verify and merge soon.

Doguhan