### PR TITLE
Encrypt falsy values, except undefined

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -131,7 +131,7 @@ const fieldEncryption = function (schema, options) {
       const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
       const fieldValue = obj[field];
 
-      if (!obj[encryptedFieldName] && fieldValue) {
+      if (!obj[encryptedFieldName] && typeof fieldValue !== "undefined") {
         if (typeof fieldValue === "string") {
           // handle strings separately to maintain searchability
           const value = encryptionStrategy(fieldValue, secret, saltGenerator);


### PR DESCRIPTION
Hi,
I faced a problem - values like "false" or "0" were not encrypted. Here is a quick fix, but please review this carefully, maybe I misunderstand the purpose of this code.