### PR TITLE
encryptedField value does not change when decrypting

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -165,8 +165,9 @@ const fieldEncryption = function (schema, options) {
             // handle strings separately to maintain searchability
             const encryptedValue = obj[field];
             obj[field] = decrypt(encryptedValue, secret);
-            obj[encryptedFieldName] = false;
           }
+          
+          obj[encryptedFieldName] = false;
         }
       }
     }


### PR DESCRIPTION
hello.
First of all, I am not good at English.
If you don't understand, please tell me again.

While using the plugin, I found an issue where field values were not encrypted and stored when empty.
After that, even if I add a value to the field and store it, there is no encryption and the plaintext is stored.

![image](https://user-images.githubusercontent.com/46643699/183575020-ecf4d38c-6586-493e-8864-c9b780e61746.png)
During encryption, encryptField was changed to true value even if the value was empty, but in decryption, even if the value was empty, it did not change to false.

The code I modified is to change encryptedField to false even if the value is empty when decrypting.

then have a nice day