### PR TITLE
Mongoose 7.X compatibility

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -267,8 +267,8 @@ const fieldEncryption = function (schema, options) {
 
   schema.pre("findOneAndUpdate", updateHook);
 
-  schema.pre("update", updateHook);
   schema.pre("updateOne", updateHook);
+  schema.pre("updateMany", updateHook);
 };
 
 module.exports.fieldEncryption = fieldEncryption;

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -178,9 +178,9 @@ const fieldEncryption = function (schema, options) {
     const next = getCompatitibleNextFunc(_next);
     for (const field of fieldsToEncrypt) {
       const encryptedFieldName = encryptedFieldNamePrefix + field;
-      this._update.$set = this._update.$set || {};
-      const plainTextValue = this._update.$set[field] || this._update[field];
-      const encryptedFieldValue = this._update.$set[encryptedFieldName] || this._update[encryptedFieldName];
+      this._updateOne.$set = this._updateOne.$set || {};
+      const plainTextValue = this._updateOne.$set[field] || this._updateOne[field];
+      const encryptedFieldValue = this._updateOne.$set[encryptedFieldName] || this._updateOne[encryptedFieldName];
 
       if (!encryptedFieldValue && plainTextValue) {
         const updateObj = {};
@@ -196,7 +196,7 @@ const fieldEncryption = function (schema, options) {
           updateObj[encryptedFieldData] = encryptionStrategy(JSON.stringify(plainTextValue), secret(), saltGenerator);
           updateObj[encryptedFieldName] = true;
         }
-        this.update({}, Object.keys(this._update.$set).length > 0 ? { $set: updateObj } : updateObj);
+        this.updateOne({}, Object.keys(this._updateOne.$set).length > 0 ? { $set: updateObj } : updateObj);
       }
     }
 


### PR DESCRIPTION
Tested for #101 

At least the `this.update` method this is now fixed.

I checked for other deprecation but could not find any.

I also updated the hook: `update` does not exist anymore due to `this.update`, and I have added `updateMany`.
I could not see why this should not be added, it was included in `update` in the first place.